### PR TITLE
Update fake_ip_filter.list

### DIFF
--- a/public/fake_ip_filter.list
+++ b/public/fake_ip_filter.list
@@ -133,6 +133,9 @@ Mijia Cloud
 +.cmbchina.com
 +.cmbimg.com
 #AdGuard
+adguardteam.github.io
+adrules.top
+anti-ad.net
 local.adguard.org
 static.adtidy.org
 #迅雷


### PR DESCRIPTION
**标题：**  
添加 AdGuardHome 黑名单下载地址和常用第三方黑名单下载地址  
**详细说明：**  
AdGuardHome 中自带的黑名单列表下载域名为 `adguardteam.github.io`，将 adg 作为下游配合 ShellCrash，且使该域名走 realip，近期不知什么原因，不管是走直连还是代理，都无法下载黑名单。只能添加常用的第三方下载域名 `anti-ad.net` 和 `adrules.top` 供有需求的人使用  
![QQ截图20240131165131](https://github.com/juewuy/ShellCrash/assets/45238096/d3dbc966-0427-4d1b-815f-a465b5e6a973)
