### PR TITLE
Resolve issue with restoring the dashboard configuration

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1433,12 +1433,14 @@ web_save(){ #最小化保存面板节点选择
 web_restore(){ #还原面板选择
 	getconfig
 	#设置循环检测面板端口以判定服务启动是否成功
-	i=1
+	test=""
+ 	i=1
 	while [ -z "$test" -a "$i" -lt 20 ];do
 		sleep 2
 		test=$(get_save http://127.0.0.1:${db_port}/configs | grep -o port)
 		i=$((i+1))
 	done
+ 	sleep 1
 	[ -n "$test" ] && {
 		#发送节点选择数据
 		[ -s ${CRASHDIR}/configs/web_save ] && {


### PR DESCRIPTION
Within the detection for the dashboard service start-up, if the "test" variable is not empty (restart scenario), the program will skip the loop and fail to restore the dashboard settings. 
On my local device, it would be more reliable to wait another 1s before the further operation.