### PR TITLE
增加检查内核多实例

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1674,6 +1674,11 @@ afstart(){ #启动后
 		$0 stop
 		start_error
 	fi
+        sleep 10
+	if [ $(pidof CrashCore | wc -w) -ge 2 ]; then
+            { sleep 5;logger 检测到运行多个实例执行重启服务;} & #推送日志
+	    ${CRASHDIR}/start.sh start
+	fi
 }
 start_error(){ #启动报错
 	if [ "$start_old" != "已开启" ] && ckcmd journalctl;then


### PR DESCRIPTION
在运行内存紧张的设备上，保守模式可以有效解决进程被终止的情况。
但是当系统内存不足时，procd 可能无法有效地管理进程的重启导致进程重复运行。

建议添加此步骤延迟10秒检查是否重复运行或者作者有更好的办法吗？