### PR TITLE
ip6tables 中，兜底时防止过滤 IP 通过新创建的 shellcrash 表进行连接

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -951,6 +951,8 @@ start_ipt_dns() { #iptables-dns通用工具
 		$1 -t nat -A $3 -p tcp -s $bypass_host -j RETURN
 		$1 -t nat -A $3 -p udp -s $bypass_host -j RETURN
 	}
+ 	ip6tables -t nat -A $3 -p tcp -s $bypass_host -j REJECT
+	ip6tables -t nat -A $3 -p udp -s $bypass_host -j REJECT
 	#局域网mac地址黑名单过滤
 	[ "$2" = 'PREROUTING' ] && [ -s "$CRASHDIR"/configs/mac ] && [ "$macfilter_type" != "白名单" ] && {
 		for mac in $(cat "$CRASHDIR"/configs/mac); do


### PR DESCRIPTION
我这边测试了没问题，如果可以的话合并一下，谢谢！