### PR TITLE
修改 webget，在curl失败后调用wget再试一次

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,8 @@ webget(){
 		[ -z "$4" ] && redirect='-L' || redirect=''
 		result=$(curl -w %{http_code} --connect-timeout 5 $progress $redirect -ko $1 $2)
 		[ -n "$(echo $result | grep -e ^2)" ] && result="200"
-	else
+	fi
+ 	if [ "$result" != "200" ];then
 		if wget --version > /dev/null 2>&1;then
 			[ "$3" = "echooff" ] && progress='-q' || progress='-q --show-progress'
 			[ "$4" = "rediroff" ] && redirect='--max-redirect=0' || redirect=''

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1876,7 +1876,8 @@ webget)
 		[ "$6" = "skipceroff" ] && certificate='' || certificate='-k'
 		result=$(curl $agent -w %{http_code} --connect-timeout 3 $progress $redirect $certificate -o "$2" "$url")
 		[ "$result" != "200" ] && export all_proxy="" && result=$(curl $agent -w %{http_code} --connect-timeout 5 $progress $redirect $certificate -o "$2" "$3")
-	else
+	fi
+ 	if [ "$result" != "200" ];then
 		if wget --version >/dev/null 2>&1; then
 			[ "$4" = "echooff" ] && progress='-q' || progress='-q --show-progress'
 			[ "$5" = "rediroff" ] && redirect='--max-redirect=0' || redirect=''


### PR DESCRIPTION
鉴于近期curl采用的[mbedTLS 3.6.0可能导致curl无法正常工作](https://github.com/curl/curl/issues/13653)，故在curl失败后调用wget再试一次。