### PR TITLE
feat(firewall/set_cust_host_ipv4): 允许使用自定义网段覆盖默认透明路由网段

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -723,16 +723,27 @@ setipv6(){ #ipv6设置
 	esac
 }
 setfirewall(){ #防火墙设置
-	set_cust_host_ipv4(){		
+	set_cust_host_ipv4(){
+		[ -z "$replace_default_host_ipv4" ] && replace_default_host_ipv4="未开启"
+
 		echo -----------------------------------------------
-		echo -e "当前已自动设置透明路由的网段为: \033[32m$(ip a 2>&1 | grep -w 'inet' | grep 'global' | grep 'br' | grep -v 'iot' | grep -E ' 1(92|0|72)\.' | sed 's/.*inet.//g' | sed 's/br.*$//g' | sed 's/metric.*$//g' | tr '\n' ' ' && echo ) \033[0m"
+		echo -e "当前默认透明路由的网段为: \033[32m$(ip a 2>&1 | grep -w 'inet' | grep 'global' | grep 'br' | grep -v 'iot' | grep -E ' 1(92|0|72)\.' | sed 's/.*inet.//g' | sed 's/br.*$//g' | sed 's/metric.*$//g' | tr '\n' ' ' && echo ) \033[0m"
 		echo -e "当前已添加的自定义网段为:\033[36m$cust_host_ipv4\033[0m"
-		echo -----------------------------------------------	
-		echo -e "\033[33m自定义网段不会覆盖自动获取的网段地址，无需重复添加\033[0m"
+		echo -----------------------------------------------
 		echo -e " 1 移除所有自定义网段"
+		echo -e " 2 使用自定义网段覆盖默认网段	\033[36m$replace_default_host_ipv4\033[0m"
 		echo -e " 0 返回上级菜单"
-		read -p "请输入需要额外添加的网段 > " text
+		read -p "请输入对应的序号或需要额外添加的网段 > " text
 		case $text in
+		2)
+			if [ "$replace_default_host_ipv4" == "未禁用" ]; then
+				replace_default_host_ipv4="已禁用"
+			else
+				replace_default_host_ipv4="未禁用"
+			fi
+			setconfig replace_default_host_ipv4 "$replace_default_host_ipv4"
+			set_cust_host_ipv4
+		;;
 		1)
 			unset cust_host_ipv4
 			setconfig cust_host_ipv4

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -194,7 +194,11 @@ getlanip() { #获取局域网host地址
 		sleep 1 && i=$((i + 1))
 	done
 	#添加自定义ipv4局域网网段
-	host_ipv4="$host_ipv4$cust_host_ipv4"
+	if [ "$replace_default_host_ipv4" == "未禁用" ]; then
+		host_ipv4="$cust_host_ipv4"
+	else
+		host_ipv4="$host_ipv4$cust_host_ipv4"
+	fi
 	#缺省配置
 	[ -z "$host_ipv4" ] && host_ipv4='192.168.0.0/16 10.0.0.0/12 172.16.0.0/12'
 	host_ipv6="fe80::/10 fd00::/8 $host_ipv6"


### PR DESCRIPTION
在`内核进阶设置`>`配置公网及局域网防火墙`>`自定义透明路由ipv4网段`添加了一个`使用自定义网段覆盖默认网段`的选项。
该选项允许用户使用自定义网段覆盖默认的透明路由网段，而不是使默认网段和自定义网段共存的方式。
同时修改了同级配置页面中的相关描述以适配改动。

默认为`已禁用`，不影响当前用户使用。