### PR TITLE
支持自定义配置文件的更新脚本

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -291,8 +291,26 @@ get_core_config() { #下载内核配置文件
 	#获取在线config文件
 	core_config_new="$TMPDIR"/${target}_config.${format}
 	rm -rf ${core_config_new}
-	$0 webget "$core_config_new" "$Https"
+	if [ "$disoverride" = "1" ]; then
+		if [ -x "$custom_update_config_script" ]; then
+			core_check
+			"$custom_update_config_script" "$core_config_new" "$Https" "$TMPDIR" "$TMPDIR"/CrashCore
+		else
+			echo -----------------------------------------------
+			logger "未设定自定义配置文件的更新脚本，无法更新！" 31
+			echo -----------------------------------------------
+			exit 1
+		fi
+	else
+		$0 webget "$core_config_new" "$Https"
+	fi
 	if [ "$?" = "1" ]; then
+		if [ "$disoverride" = "1" ]; then
+			echo -----------------------------------------------
+			logger "更新自定义配置文件失败！" 31
+			echo -----------------------------------------------
+			exit 1
+		fi
 		if [ -z "$url_type" ]; then
 			echo -----------------------------------------------
 			logger "配置文件获取失败！" 31


### PR DESCRIPTION
当禁用了配置文件覆写功能时，ShellCrash 将直接使用自定义配置文件。该改动主要是为了支持自定义配置文件的更新脚本。

1. 新增设定项为 "custom_update_config_script"，指向更新脚本路径，该脚本需要有可执行权限；
2. 该脚本被调用时，传入的参数如下： new_config_file_path, subscription_update_url, tmp_working_dir, core_full_path
3. 该脚本需要确保将更新后的配置文件写入 new_config_file_path， 正常更新后返回值为0，若有任何错误则返回值为1。

```sh
# sample usage
$ cat /data/ShellCrash/configs/ShellCrash.cfg
custom_update_config_script='/data/ShellCrash/tools/customize-update-singbox-config.sh'
```

```sh
# sampe update script for singbox
# example of "/tmp/base.json":
#   https://gitlab.com/silverzhaojr/mess/-/blob/main/singbox-config/base.json
#
$ cat /data/ShellCrash/tools/customize-update-singbox-config.sh
#!/bin/sh

# $1: new config path
# $2: subscription update url
# $3: tmp working dir
# $4: full path of core

new_config_path="$1"
subscription_update_url="$2"
tmp_working_dir="$3"
core_path="$4"

cd "$tmp_working_dir" && \
mkdir -p sb-tmp && cd sb-tmp && \
curl -o sub.json "$subscription_update_url" && \
"$core_path" format -c sub.json | sed -n '/"outbounds":/,/^  "[a-z]/p' | sed '$d' > o.json && \
echo "{" > outbounds.json && sed  's/^  ],$/  ]/' o.json >> outbounds.json && echo ""}"" >> outbounds.json && \
"$core_path" merge config.json -c /tmp/base.json -c outbounds.json && \
"$core_path" check -c config.json && \
mv config.json "$new_config_path" && \
cd .. && rm -rf sb-tmp && \
exit 0

exit 1
```
