### PR TITLE
修改小米相关域名走 realip

### DIFF
--- a/.github/workflows/bin_update.yml
+++ b/.github/workflows/bin_update.yml
@@ -98,7 +98,14 @@ jobs:
         rm -rf Yacd-meta-gh-pages
         rm -rf metacubexd-gh-pages
         echo 面板更新完成！
-        
+
+    - name: Update certificate
+      run: |
+        wget https://raw.githubusercontent.com/curl/curl/master/scripts/mk-ca-bundle.pl
+        chmod +x ./mk-ca-bundle.pl
+        ./mk-ca-bundle.pl
+        rm -f mk-ca-bundle.pl certdata.txt
+
     - name: Update GeoIP
       run: |
         cd bin
@@ -112,7 +119,7 @@ jobs:
         curl -kfSL -o geodata/geosite_cn.db https://github.com/SagerNet/sing-geosite/releases/latest/download/geosite-cn.db
         curl -kfSL -o geodata/srs_geoip_cn.srs https://raw.githubusercontent.com/SagerNet/sing-geoip/rule-set/geoip-cn.srs
         curl -kfSL -o geodata/srs_geosite_cn.srs https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/geosite-geolocation-cn.srs
-        curl -kfSL -o fix/ca-certificates.crt https://raw.githubusercontent.com/P3TERX/ca-certificates.crt/download/ca-certificates.crt
+        mv -f ./ca-bundle.crt ./fix/ca-certificates.crt
         sed -i "s/GeoIP_v=.*/GeoIP_v=$(date '+%Y%m%d')/" version #修改版本号
         echo 数据库及根证书文件更新完成！
 

--- a/public/fake_ip_filter.list
+++ b/public/fake_ip_filter.list
@@ -133,7 +133,7 @@ shark007.net
 #Mijia
 Mijia Cloud
 #Xiaomi
-weatherapi.market.xiaomi.com
++.market.xiaomi.com
 #招商银行
 +.cmbchina.com
 +.cmbimg.com


### PR DESCRIPTION
小米天气又新增了一个域名 `wtradv.market.xiaomi.com` 必须走 realip 才能正常显示“降水预报”，所以改成 `+.market.xiaomi.com` 后缀格式