### PR TITLE
fix DoH/DoT always fallback check /etc/ssl/

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -608,9 +608,8 @@ setdns(){ #DNS设置
 		
 	elif [ "$num" = 4 ]; then
 		echo -----------------------------------------------
-		openssldir=$(openssl version -a 2>&1 | grep OPENSSLDIR | awk -F "\"" '{print $2}')
-		[ -z "$openssldir" ] && openssldir=/etc/ssl
-		if [ -s "$openssldir/certs/ca-certificates.crt" ];then
+		openssldir="$(openssl version -d 2>&1 | awk -F '"' '{print $2}')"
+		if [ -s "$openssldir/certs/ca-certificates.crt" -o "/etc/ssl/certs/ca-certificates.crt" ];then
 			dns_nameserver='https://223.5.5.5/dns-query, https://doh.pub/dns-query, tls://dns.rubyfish.cn:853'
 			dns_fallback='tls://1.0.0.1:853, tls://8.8.4.4:853, https://doh.opendns.com/dns-query'
 			setconfig dns_nameserver \'"$dns_nameserver"\'

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -609,7 +609,7 @@ setdns(){ #DNS设置
 	elif [ "$num" = 4 ]; then
 		echo -----------------------------------------------
 		openssldir="$(openssl version -d 2>&1 | awk -F '"' '{print $2}')"
-		if [ -s "$openssldir/certs/ca-certificates.crt" -o "/etc/ssl/certs/ca-certificates.crt" ];then
+		if [ -s "$openssldir/certs/ca-certificates.crt" -o -s "/etc/ssl/certs/ca-certificates.crt" ];then
 			dns_nameserver='https://223.5.5.5/dns-query, https://doh.pub/dns-query, tls://dns.rubyfish.cn:853'
 			dns_fallback='tls://1.0.0.1:853, tls://8.8.4.4:853, https://doh.opendns.com/dns-query'
 			setconfig dns_nameserver \'"$dns_nameserver"\'

--- a/scripts/webget.sh
+++ b/scripts/webget.sh
@@ -1943,10 +1943,13 @@ getcrt(){ #下载根证书文件
 	fi
 }
 setcrt(){
-	openssldir=$(openssl version -a 2>&1 | grep OPENSSLDIR | awk -F "\"" '{print $2}')
-	[ -z "$openssldir" ] && openssldir=/etc/ssl
+	openssldir="$(openssl version -d 2>&1 | awk -F '"' '{print $2}')"
+	if [ -d "$openssldir/certs/" ];then
+ 		crtdir="$openssldir/certs/ca-certificates.crt"
+   	else
+    		crtdir="/etc/ssl/certs/ca-certificates.crt"
+ 	fi
 	if [ -n "$openssldir" ];then
-		crtdir="$openssldir/certs/ca-certificates.crt"
 		echo -----------------------------------------------
 		echo -e "\033[36m安装/更新本地根证书文件(ca-certificates.crt)\033[0m"
 		echo -e "\033[33m用于解决证书校验错误，x509报错等问题\033[0m"
@@ -2273,8 +2276,8 @@ userguide(){
 		}
 	fi
 	#检测及下载根证书
-	openssldir=$(openssl version -a 2>&1 | grep OPENSSLDIR | awk -F "\"" '{print $2}')
-	[ -z "$openssldir" ] && openssldir=/etc/ssl
+	openssldir="$(openssl version -d 2>&1 | awk -F '"' '{print $2}')"
+	[ ! -d "$openssldir/certs" ] && openssldir=/etc/ssl
 	if [ -d $openssldir/certs -a ! -f $openssldir/certs/ca-certificates.crt ];then
 		echo -----------------------------------------------
 		echo -e "\033[33m当前设备未找到根证书文件\033[0m"


### PR DESCRIPTION
在华硕路由器中，openssldir 并不指向 `/etc/ssl/`:

```sh
# openssl version -d
OPENSSLDIR: "/etc"
```

旧的判断逻辑会导致无法使用DoH/DoT，其实是可以使用的，因为openssl内部会fallback，优先查找 `OPENSSLDIR`，找不到证书文件的时候会fallback到 `/etc/ssl/certs/`，所以改了下判断逻辑。

实际在路由上 curl, wget 之类的都可以可以访问https网站没有问题的，所以做一下兼容性调整