### PR TITLE
fix(menu.sh): host_opt初始值“已开启”和与“已启用”不匹配

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -561,7 +561,7 @@ setport() { #端口设置
 setdns() { #DNS设置
 	[ -z "$dns_nameserver" ] && dns_nameserver='114.114.114.114, 223.5.5.5'
 	[ -z "$dns_fallback" ] && dns_fallback='1.0.0.1, 8.8.4.4'
-	[ -z "$hosts_opt" ] && hosts_opt=已开启
+	[ -z "$hosts_opt" ] && hosts_opt=已启用
 	[ -z "$dns_redir" ] && dns_redir=未开启
 	[ -z "$dns_no" ] && dns_no=未禁用
 	echo -----------------------------------------------


### PR DESCRIPTION
默认值为"已启用"：
`[ -z "$hosts_opt" ] && hosts_opt=已开启`

实际使用时，判断启用却使用的"已启用"：
`if [ "$hosts_opt" = "已启用" ]; then`