### PR TITLE
clash内核默认不支持关闭fakeip模式？

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -1422,7 +1422,7 @@ set_dns_mod() { #DNS设置
 	if [ "$crashcore" = singbox -o "$crashcore" = singboxp ]; then
 		echo -e " 3 mix混合模式：   \033[32m内部realip外部fakeip\033[0m"
 		echo -e "                   依赖geosite-cn.(db/srs)数据库"
-	elif [ "$crashcore" = meta ]; then
+	elif [ "$crashcore" = meta  -o "$crashcore" = clash]; then
 		echo -e " 2 redir_host模式：\033[32m兼容性更好\033[0m"
 		echo -e "                   需搭配加密DNS使用"
 	fi


### PR DESCRIPTION
默认下载的是clash内核，fakeip模式会导致内网各种问题（比如 nslookup命令不能用和内网部署 rustdesk server 的发卡 NAT 问题），需要手动修改为redir_host模式。 找了半天结果在这里被隐藏了，我在面板直接按2激活后内部网络就正常了，所以这里的逻辑应该是支持 redir_host 模式吧。