### PR TITLE
修复小闪存模式无法安装zashboard的问题

### DIFF
--- a/.github/workflows/bin_update.yml
+++ b/.github/workflows/bin_update.yml
@@ -49,7 +49,7 @@ jobs:
         echo 下载meta-xd面板
         curl -kfSL -o meta_xd.zip  https://github.com/MetaCubeX/metacubexd/archive/gh-pages.zip
         echo 下载zashboard面板
-        curl -kfSL -o zashboard.zip https://github.com/Zephyruso/zashboard/releases/latest/download/dist-cdn-fonts.zip
+        curl -kfSL -o zashboard.zip https://github.com/Zephyruso/zashboard/archive/gh-pages.zip
         echo 解压缩
         # unzip -o clashdb.zip > /dev/null
         unzip -o yacd.zip > /dev/null


### PR DESCRIPTION
从release中下载的压缩包没有CNAME，会导致https://github.com/juewuy/ShellCrash/blob/53a6b9f2c1b3b93759ff766eacadfbe1dd9a3887/scripts/start.sh#L1826 无法识别已安装的面板