### PR TITLE
使用 sing-box check 的返回值来判断配置文件是否正确

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -403,7 +403,7 @@ EOF
 				#插入过滤规则
 				cat >>"$TMPDIR"/dns.yaml <<EOF
     - "rule-set:geosite-cn"
-  nameserver-policy: 
+  nameserver-policy:
     "+.googleapis.cn": [$dns_fallback]
 EOF
 			}
@@ -893,8 +893,7 @@ EOF
 		}
 	done
 	#测试自定义配置文件
-	error=$("$TMPDIR"/CrashCore check -D "$BINDIR" -C "$TMPDIR"/jsons 2>&1)
-	if [ -n "$error" ]; then
+	if ! error=$("$TMPDIR"/CrashCore check -D "$BINDIR" -C "$TMPDIR"/jsons 2>&1); then
 		echo $error
 		error_file=$(echo $error | grep -Eo 'cust.*\.json' | sed 's/cust_//g')
 		[ "$error_file" = 'add_rules.json' ] && error_file="$CRASHDIR"/yamls/rules.yaml自定义规则 || error_file="$CRASHDIR"/jsons/$error_file


### PR DESCRIPTION
目前 sing-box check 有时会输出一些警告信息，但是这些不影响配置文件正常使用。
但是之前采用了校验输出内容是否为空的方式来判断配置文件是否正确，这导致一部分会产生警告的可以正常使用的配置文件无法使用。
现在改为了检查 sing-box check 的返回值的方式来判断，更加准确。