### PR TITLE
变更 tun 工作地址

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -788,7 +788,7 @@ EOF
       "interface_name": "utun",
       "address": [
         $ipv6_address
-        "172.72.0.1/30"
+        "172.18.0.1/30"
       ],
       "auto_route": false,
       "stack": "system",


### PR DESCRIPTION
[RFC1918](https://www.rfc-editor.org/rfc/rfc1918.html) 规定的私有 IP 地址中 172 这一部分是 172.16.0.0/12，即 172.16.0.0 – 172.31.255.255。

`172.72.0.1/30` 不在这个范围内，理论上存在和公网 IP 地址冲突的情况；现在改为 sing-box 官网说明上使用的 `172.18.0.1/30`