### PR TITLE
fix(task): 修复自动任务名称包含括号等特殊字符导致脚本语法报错的问题 (fixes #1331)

### DIFF
--- a/scripts/menus/5_task.sh
+++ b/scripts/menus/5_task.sh
@@ -23,7 +23,7 @@ set_cron() {
         "0) $TASK5_NO"
     read -r -p "$COMMON_INPUT> " res
     if [ "$res" = '1' ]; then
-        task_txt="$min $hour * * $week $CRASHDIR/task/task.sh $task_id $cron_time$task_name"
+        task_txt="$min $hour * * $week $CRASHDIR/task/task.sh $task_id \"$cron_time$task_name\""
         cronset "$cron_time$task_name" "$task_txt"
         msg_alert -t 0 "$TASK5_TASK_PREFIX$cron_time$task_name$TASK5_TASK_ADDED"
     fi
@@ -38,11 +38,11 @@ set_service() {
     [ -s "$task_file" ] && sed -i "/$3/d" "$task_file"
     # 运行时每分钟执行的任务特殊处理
     if [ "$1" = "running" ]; then
-        task_txt="$4 $CRASHDIR/task/task.sh $2 $3"
+        task_txt="$4 $CRASHDIR/task/task.sh $2 \"$3\""
         echo "$task_txt" >>"$task_file"
         [ -n "$(pidof CrashCore)" ] && cronset "$3" "$task_txt"
     else
-        echo "$CRASHDIR/task/task.sh $2 $3" >>"$task_file"
+        echo "$CRASHDIR/task/task.sh $2 \"$3\"" >>"$task_file"
     fi
     content_line "【$3】\033[32m$COMMON_SUCCESS\033[0m"
     sleep 1
@@ -144,11 +144,12 @@ task_del() {
     # 删除定时任务
     cronset "$1"
     # 删除条件任务
-    sed -i "/$1/d" "$TASKCFGDIR"/cron 2>/dev/null
-    sed -i "/$1/d" "$TASKCFGDIR"/bfstart 2>/dev/null
-    sed -i "/$1/d" "$TASKCFGDIR"/afstart 2>/dev/null
-    sed -i "/$1/d" "$TASKCFGDIR"/running 2>/dev/null
-    sed -i "/$1/d" "$TASKCFGDIR"/affirewall 2>/dev/null
+    [ -f "$TASKCFGDIR"/cron ] && sed -i "/$1/d" "$TASKCFGDIR"/cron 2>/dev/null
+    [ -f "$TASKCFGDIR"/bfstart ] && sed -i "/$1/d" "$TASKCFGDIR"/bfstart 2>/dev/null
+    [ -f "$TASKCFGDIR"/afstart ] && sed -i "/$1/d" "$TASKCFGDIR"/afstart 2>/dev/null
+    [ -f "$TASKCFGDIR"/running ] && sed -i "/$1/d" "$TASKCFGDIR"/running 2>/dev/null
+    [ -f "$TASKCFGDIR"/affirewall ] && sed -i "/$1/d" "$TASKCFGDIR"/affirewall 2>/dev/null
+    return 0
 }
 
 # 任务条件选择菜单
@@ -293,7 +294,10 @@ task_manager() {
                         break
                     fi
                 else
-                    task_des=$(echo "$task_txt" | awk '{print $2}')
+                    task_des=${task_txt#* }
+                    task_des=${task_des#"${task_des%%[! ]*}"}
+                    task_des=${task_des#\"}
+                    task_des=${task_des%\"}
                     task_name=$(cat "$CRASHDIR"/task/task_${i18n}.list "$TASKCFGDIR"/task.user 2>/dev/null | grep "$task_id" | awk -F '#' '{print $3}')
                     comp_box "$TASK5_CURRENT_TASK\033[36m$task_des\033[0m"
                     btm_box "1) $TASK5_EDIT_TASK" \
@@ -359,7 +363,7 @@ task_recom() {
         separator_line "="
         set_service running "106" "$TASK_RECOM_ITEM_1" "*/10 * * * *"
         set_service afstart "107" "$TASK_RECOM_ITEM_2"
-        cronset "$TASK_RECOM_ITEM_3" "0 3 * * * ${CRASHDIR}/task/task.sh 103 $TASK_RECOM_ITEM_3" &&
+        cronset "$TASK_RECOM_ITEM_3" "0 3 * * * ${CRASHDIR}/task/task.sh 103 \"$TASK_RECOM_ITEM_3\"" &&
             content_line "【$TASK_RECOM_ITEM_3】\033[32m$COMMON_SUCCESS\033[0m"
         separator_line "="
     }


### PR DESCRIPTION
### 关联 Issue
Fixes #1331

### 问题分析
在基于 BusyBox 的嵌入式设备（如 OpenWrt / 小米路由器）中，当配置了任务 105「服务启动后热更新在线订阅(不重启)」时：
1. `scripts/menus/5_task.sh` 中的 `set_service` 函数在向 `$TASKCFGDIR/afstart`、`$TASKCFGDIR/bfstart` 写入任务命令时未对任务说明参数 `$3` 加引号保护，生成的命令行形如：
   ```sh
   /userdisk/ShellCrash/task/task.sh 105 服务启动后热更新在线订阅(不重启)
   ```
2. 服务启动时由 `afstart.sh` 执行 `. "$TASKCFGDIR"/afstart`，BusyBox `ash` 将未加引号的 `(不重启)` 识别为子 shell 语法符号，报错 `syntax error: unexpected "("` 并中断执行。
3. 同样的情况也存在于 `running` 任务及 `crontab` 定时任务中。

### 修改内容
1. **参数加引号保护**：在 `set_service`（afstart/bfstart/running）以及 `set_cron` 中，写入命令时对任务说明参数统一添加双引号包裹（`\"$3\"`）。
2. **任务管理器提取逻辑优化**：在 `task_manager` 中，由原有的 `awk '{print $2}'` 改为纯 POSIX 参数展开剔除命令前缀并安全剥离外层双引号，确保带空格或带引号的任务说明在菜单中正常显示、执行以及通过 `task_del` 准确删除。
3. **健壮性优化**：`task_del` 增加 `[ -f ... ]` 文件存在性检查，避免无效报错。

### 现场实测验证
- [x] **本地语法检查**：`sh -n scripts/menus/5_task.sh` 校验通过。
- [x] **路由器实机测试（小米路由器 IPQ5332 / OpenWrt 18.06 BusyBox ash）**：
  - 测试直接 source 包含 `(不重启)` 的 `afstart` 文件：修复前报错 `ash: syntax error: unexpected "("`（退出码 2）；修复后执行正常，退出码 0。
  - 测试任务管理器的解析、展示与 `task_del` 删除匹配完全正常，任务删除后配置文件无残留。